### PR TITLE
ci: migrate container registry from DockerHub to GHCR

### DIFF
--- a/.github/workflows/docker-build-reusable.yml
+++ b/.github/workflows/docker-build-reusable.yml
@@ -24,15 +24,13 @@ on:
         type: boolean
         default: false
         description: 'Whether this is a release build (push latest tag)'
-    secrets:
-      DOCKERHUB_USERNAME:
-        required: true
-      DOCKERHUB_TOKEN:
-        required: true
 
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -42,54 +40,67 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set platform tag
-        id: platform
+      - name: Set platform tag and repo owner
+        id: vars
         run: |
           PLATFORM_TAG=$(echo "${{ matrix.platform }}" | tr '/' '-')
           echo "tag=${PLATFORM_TAG}" >> $GITHUB_OUTPUT
+          OWNER="${{ github.repository_owner }}"
+          echo "owner=${OWNER,,}" >> $GITHUB_OUTPUT
 
       - uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-${{ steps.platform.outputs.tag }}
+          tags: ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-${{ steps.vars.outputs.tag }}
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ inputs.image_name }}-${{ steps.platform.outputs.tag }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}-${{ steps.platform.outputs.tag }}
+          cache-from: type=gha,scope=${{ inputs.image_name }}-${{ steps.vars.outputs.tag }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}-${{ steps.vars.outputs.tag }}
           provenance: false
 
   manifest:
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Set repo owner lowercase
+        id: vars
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          echo "owner=${OWNER,,}" >> $GITHUB_OUTPUT
+
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push manifest
         run: |
           docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }} \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-amd64 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }} \
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-amd64 \
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-arm64
+          docker manifest push ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}
 
       - name: Create and push latest manifest
         if: inputs.is_release
         run: |
           docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:latest \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-amd64 \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}:latest
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:latest \
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-amd64 \
+            ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:${{ inputs.image_tag }}-linux-arm64
+          docker manifest push ghcr.io/${{ steps.vars.outputs.owner }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
       is_release: ${{ steps.tag.outputs.is_release }}
       previous_tag: ${{ steps.prev_tag.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history for tag comparison
 
@@ -120,9 +120,6 @@ jobs:
       context: .
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   sidecar:
     needs: changes
@@ -134,9 +131,6 @@ jobs:
       context: docker/sidecar
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   python:
     needs: changes
@@ -148,9 +142,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   javascript:
     needs: changes
@@ -162,9 +153,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   typescript:
     needs: changes
@@ -176,9 +164,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   go:
     needs: changes
@@ -190,9 +175,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   java:
     needs: changes
@@ -204,9 +186,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   c-cpp:
     needs: changes
@@ -218,9 +197,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   php:
     needs: changes
@@ -232,9 +208,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   rust:
     needs: changes
@@ -246,9 +219,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   r:
     needs: changes
@@ -260,9 +230,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   fortran:
     needs: changes
@@ -274,9 +241,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   d:
     needs: changes
@@ -288,9 +252,6 @@ jobs:
       context: docker
       image_tag: ${{ needs.changes.outputs.image_tag }}
       is_release: ${{ needs.changes.outputs.is_release == 'true' }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # ==================== Retag Unchanged Images (for releases) ====================
   # These jobs run when an image didn't change but we still want it tagged with the new version
@@ -307,9 +268,6 @@ jobs:
       image_name: librecodeinterpreter-api
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-sidecar:
     needs: changes
@@ -323,9 +281,6 @@ jobs:
       image_name: librecodeinterpreter-sidecar
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-python:
     needs: changes
@@ -339,9 +294,6 @@ jobs:
       image_name: librecodeinterpreter-python
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-javascript:
     needs: changes
@@ -355,9 +307,6 @@ jobs:
       image_name: librecodeinterpreter-javascript
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-typescript:
     needs: changes
@@ -371,9 +320,6 @@ jobs:
       image_name: librecodeinterpreter-typescript
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-go:
     needs: changes
@@ -387,9 +333,6 @@ jobs:
       image_name: librecodeinterpreter-go
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-java:
     needs: changes
@@ -403,9 +346,6 @@ jobs:
       image_name: librecodeinterpreter-java
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-c-cpp:
     needs: changes
@@ -419,9 +359,6 @@ jobs:
       image_name: librecodeinterpreter-c-cpp
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-php:
     needs: changes
@@ -435,9 +372,6 @@ jobs:
       image_name: librecodeinterpreter-php
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-rust:
     needs: changes
@@ -451,9 +385,6 @@ jobs:
       image_name: librecodeinterpreter-rust
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-r:
     needs: changes
@@ -467,9 +398,6 @@ jobs:
       image_name: librecodeinterpreter-r
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-fortran:
     needs: changes
@@ -483,9 +411,6 @@ jobs:
       image_name: librecodeinterpreter-fortran
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   retag-d:
     needs: changes
@@ -499,6 +424,3 @@ jobs:
       image_name: librecodeinterpreter-d
       new_tag: ${{ needs.changes.outputs.image_tag }}
       previous_tag: ${{ needs.changes.outputs.previous_tag }}
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-retag-reusable.yml
+++ b/.github/workflows/docker-retag-reusable.yml
@@ -15,24 +15,27 @@ on:
         required: true
         type: string
         description: 'Previous tag to copy from'
-    secrets:
-      DOCKERHUB_USERNAME:
-        required: true
-      DOCKERHUB_TOKEN:
-        required: true
 
 jobs:
   retag:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retag image
         run: |
-          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image_name }}"
+          OWNER="${{ github.repository_owner }}"
+          OWNER_LC="${OWNER,,}"
+          IMAGE="ghcr.io/${OWNER_LC}/${{ inputs.image_name }}"
           OLD_TAG="${{ inputs.previous_tag }}"
           NEW_TAG="${{ inputs.new_tag }}"
 

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -9,14 +9,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
-        with:
-          version: 'v3.14.0'
 
       - name: Set chart version from tag
         id: version
@@ -31,6 +32,9 @@ jobs:
             VERSION="${TAG#v}"
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
           fi
+          # Set lowercase owner for GHCR
+          OWNER="${{ github.repository_owner }}"
+          echo "owner=${OWNER,,}" >> $GITHUB_OUTPUT
 
       - name: Update Chart.yaml version
         run: |
@@ -46,11 +50,11 @@ jobs:
           helm package helm-deployments/librecodeinterpreter --destination ./helm-package
           ls -la ./helm-package
 
-      - name: Login to Artifactory OCI registry
+      - name: Login to GitHub Container Registry
         run: |
-          helm registry login -u ${{ secrets.ARTIFACTORY_USERNAME }} -p ${{ secrets.ARTIFACTORY_TOKEN }} ${{ secrets.ARTIFACTORY_HOST }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push to Artifactory
+      - name: Push to GitHub Container Registry
         run: |
           CHART_PACKAGE=$(ls ./helm-package/*.tgz)
-          helm push "${CHART_PACKAGE}" oci://${{ secrets.ARTIFACTORY_HOST }}/${{ secrets.ARTIFACTORY_REPO }}
+          helm push "${CHART_PACKAGE}" oci://ghcr.io/${{ steps.version.outputs.owner }}/charts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   python-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,8 @@ config/local.py
 *.db-journal
 *.db-wal
 *.db-shm
+
+# temporary
+review/
+REVIEW.md
+security_finding.md


### PR DESCRIPTION
- Replace DockerHub authentication with GitHub Container Registry
- Use GITHUB_TOKEN instead of external secrets
- Add lowercase conversion for repository owner (GHCR requirement)
- Add docker/setup-buildx-action to retag workflow
- Migrate Helm chart publishing from Artifactory to GitHub OCI registry
- Update actions/checkout to v6
