### PR TITLE
Image repos

### DIFF
--- a/helm-deployments/k8sinterpreter/templates/configmap.yaml
+++ b/helm-deployments/k8sinterpreter/templates/configmap.yaml
@@ -16,10 +16,12 @@ data:
   # Kubernetes Configuration
   K8S_NAMESPACE: {{ include "k8sinterpreter.executionNamespace" . | quote }}
   K8S_SERVICE_ACCOUNT: {{ include "k8sinterpreter.executorServiceAccountName" . | quote }}
-  K8S_SIDECAR_IMAGE: {{ .Values.execution.sidecar.image | quote }}
+  {{- $imageTag := .Values.execution.imageTag | default .Chart.AppVersion }}
+  {{- $sidecarTag := .Values.execution.sidecar.tag | default .Chart.AppVersion }}
+  K8S_SIDECAR_IMAGE: "{{ .Values.execution.sidecar.repository }}:{{ $sidecarTag }}"
   K8S_SIDECAR_PORT: {{ .Values.execution.sidecar.port | quote }}
   K8S_IMAGE_REGISTRY: {{ .Values.execution.imageRegistry | quote }}
-  K8S_IMAGE_TAG: {{ .Values.execution.imageTag | quote }}
+  K8S_IMAGE_TAG: {{ $imageTag | quote }}
   K8S_IMAGE_PULL_POLICY: {{ .Values.execution.imagePullPolicy | quote }}
   K8S_CPU_LIMIT: {{ .Values.execution.resources.limits.cpu | quote }}
   K8S_MEMORY_LIMIT: {{ .Values.execution.resources.limits.memory | quote }}
@@ -44,43 +46,37 @@ data:
   POD_POOL_F90: {{ .Values.execution.languages.fortran.poolSize | quote }}
   POD_POOL_D: {{ .Values.execution.languages.d.poolSize | quote }}
 
-  # Per-language image overrides (optional - falls back to registry/tag pattern)
-  {{- if .Values.execution.languages.python.image }}
-  LANG_IMAGE_PY: {{ .Values.execution.languages.python.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.javascript.image }}
-  LANG_IMAGE_JS: {{ .Values.execution.languages.javascript.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.typescript.image }}
-  LANG_IMAGE_TS: {{ .Values.execution.languages.typescript.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.go.image }}
-  LANG_IMAGE_GO: {{ .Values.execution.languages.go.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.java.image }}
-  LANG_IMAGE_JAVA: {{ .Values.execution.languages.java.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.rust.image }}
-  LANG_IMAGE_RS: {{ .Values.execution.languages.rust.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.c.image }}
-  LANG_IMAGE_C: {{ .Values.execution.languages.c.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.cpp.image }}
-  LANG_IMAGE_CPP: {{ .Values.execution.languages.cpp.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.php.image }}
-  LANG_IMAGE_PHP: {{ .Values.execution.languages.php.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.r.image }}
-  LANG_IMAGE_R: {{ .Values.execution.languages.r.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.fortran.image }}
-  LANG_IMAGE_F90: {{ .Values.execution.languages.fortran.image | quote }}
-  {{- end }}
-  {{- if .Values.execution.languages.d.image }}
-  LANG_IMAGE_D: {{ .Values.execution.languages.d.image | quote }}
-  {{- end }}
+  # Per-language images
+  # Uses full image if specified, otherwise builds from registry-suffix:tag
+  # where suffix defaults to the language name
+  {{- $registry := .Values.execution.imageRegistry }}
+  {{- $defaultTag := .Values.execution.imageTag | default .Chart.AppVersion }}
+  {{- $defaultImage := printf "%s-%s:%s" $registry "python" $defaultTag }}
+  LANG_IMAGE_PY: {{ .Values.execution.languages.python.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "javascript" $defaultTag }}
+  LANG_IMAGE_JS: {{ .Values.execution.languages.javascript.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "typescript" $defaultTag }}
+  LANG_IMAGE_TS: {{ .Values.execution.languages.typescript.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "go" $defaultTag }}
+  LANG_IMAGE_GO: {{ .Values.execution.languages.go.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "java" $defaultTag }}
+  LANG_IMAGE_JAVA: {{ .Values.execution.languages.java.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "rust" $defaultTag }}
+  LANG_IMAGE_RS: {{ .Values.execution.languages.rust.image | default $defaultImage | quote }}
+  {{- $suffix := .Values.execution.languages.c.imageSuffix | default "c" }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry $suffix $defaultTag }}
+  LANG_IMAGE_C: {{ .Values.execution.languages.c.image | default $defaultImage | quote }}
+  {{- $suffix = .Values.execution.languages.cpp.imageSuffix | default "cpp" }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry $suffix $defaultTag }}
+  LANG_IMAGE_CPP: {{ .Values.execution.languages.cpp.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "php" $defaultTag }}
+  LANG_IMAGE_PHP: {{ .Values.execution.languages.php.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "r" $defaultTag }}
+  LANG_IMAGE_R: {{ .Values.execution.languages.r.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "fortran" $defaultTag }}
+  LANG_IMAGE_F90: {{ .Values.execution.languages.fortran.image | default $defaultImage | quote }}
+  {{- $defaultImage = printf "%s-%s:%s" $registry "d" $defaultTag }}
+  LANG_IMAGE_D: {{ .Values.execution.languages.d.image | default $defaultImage | quote }}
 
   # Execution Limits
   MAX_EXECUTION_TIME: {{ .Values.execution.maxExecutionTime | quote }}

--- a/helm-deployments/k8sinterpreter/values.yaml
+++ b/helm-deployments/k8sinterpreter/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 image:
   repository: ghcr.io/wipash/k8sinterpreter-api
   pullPolicy: IfNotPresent
-  tag: "latest"
+  # tag defaults to Chart.AppVersion if not specified
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -149,12 +150,12 @@ execution:
 
   # Image registry configuration
   # Images are named: {imageRegistry}-{language}:{imageTag}
-  # e.g., aronmuon/k8sinterpreter-python:latest
-  imageRegistry: "aronmuon/k8sinterpreter"
-  imageTag: "latest"
+  # e.g., ghcr.io/wipash/k8sinterpreter-python:1.4.0
+  imageRegistry: "ghcr.io/wipash/k8sinterpreter"
+  # imageTag defaults to Chart.AppVersion if not specified
+  imageTag: ""
   # Image pull policy for execution pods (IfNotPresent, Always, Never)
-  # Use "Always" when using :latest tags to ensure fresh images
-  imagePullPolicy: "Always"
+  imagePullPolicy: "IfNotPresent"
 
   # Service account for execution pods (with pod/job create permissions)
   serviceAccount:
@@ -164,48 +165,44 @@ execution:
 
   # Sidecar container configuration
   sidecar:
-    image: aronmuon/k8sinterpreter-sidecar:latest
+    repository: ghcr.io/wipash/k8sinterpreter-sidecar
+    # tag defaults to Chart.AppVersion if not specified
+    tag: ""
     port: 8080
 
   # Per-language pool configuration
   # poolSize > 0: warm pods maintained
   # poolSize = 0: use Jobs (cold start)
+  # Images default to {imageRegistry}-{language}:{imageTag or appVersion}
+  # Set image: to override with a custom image for a specific language
   languages:
     python:
-      image: ghcr.io/wipash/k8sinterpreter-python:1.3.0
       poolSize: 5
     javascript:
-      image: ghcr.io/wipash/k8sinterpreter-javascript:1.3.0
       poolSize: 2
     typescript:
-      image: ghcr.io/wipash/k8sinterpreter-typescript:1.3.0
       poolSize: 0
     go:
-      image: ghcr.io/wipash/k8sinterpreter-go:1.3.0
       poolSize: 0
     java:
-      image: ghcr.io/wipash/k8sinterpreter-java:1.3.0
       poolSize: 0
     rust:
-      image: ghcr.io/wipash/k8sinterpreter-rust:1.3.0
       poolSize: 0
     c:
-      image: ghcr.io/wipash/k8sinterpreter-c-cpp:1.3.0
+      # Uses c-cpp image by default
+      imageSuffix: "c-cpp"
       poolSize: 0
     cpp:
-      image: ghcr.io/wipash/k8sinterpreter-c-cpp:1.3.0
+      # Uses c-cpp image by default
+      imageSuffix: "c-cpp"
       poolSize: 0
     php:
-      image: ghcr.io/wipash/k8sinterpreter-php:1.3.0
       poolSize: 0
     r:
-      image: ghcr.io/wipash/k8sinterpreter-r:1.3.0
       poolSize: 0
     fortran:
-      image: ghcr.io/wipash/k8sinterpreter-fortran:1.3.0
       poolSize: 0
     d:
-      image: ghcr.io/wipash/k8sinterpreter-d:1.3.0
       poolSize: 0
 
   # Job settings (for languages with poolSize=0)

--- a/helm-deployments/k8sinterpreter/values.yaml
+++ b/helm-deployments/k8sinterpreter/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: aronmuon/k8sinterpreter-api
+  repository: ghcr.io/wipash/k8sinterpreter-api
   pullPolicy: IfNotPresent
   tag: "latest"
 
@@ -172,40 +172,40 @@ execution:
   # poolSize = 0: use Jobs (cold start)
   languages:
     python:
-      image: aronmuon/k8sinterpreter-python:latest
+      image: ghcr.io/wipash/k8sinterpreter-python:1.3.0
       poolSize: 5
     javascript:
-      image: aronmuon/k8sinterpreter-javascript:latest
+      image: ghcr.io/wipash/k8sinterpreter-javascript:1.3.0
       poolSize: 2
     typescript:
-      image: aronmuon/k8sinterpreter-typescript:latest
+      image: ghcr.io/wipash/k8sinterpreter-typescript:1.3.0
       poolSize: 0
     go:
-      image: aronmuon/k8sinterpreter-go:latest
+      image: ghcr.io/wipash/k8sinterpreter-go:1.3.0
       poolSize: 0
     java:
-      image: aronmuon/k8sinterpreter-java:latest
+      image: ghcr.io/wipash/k8sinterpreter-java:1.3.0
       poolSize: 0
     rust:
-      image: aronmuon/k8sinterpreter-rust:latest
+      image: ghcr.io/wipash/k8sinterpreter-rust:1.3.0
       poolSize: 0
     c:
-      image: aronmuon/k8sinterpreter-c-cpp:latest
+      image: ghcr.io/wipash/k8sinterpreter-c-cpp:1.3.0
       poolSize: 0
     cpp:
-      image: aronmuon/k8sinterpreter-c-cpp:latest
+      image: ghcr.io/wipash/k8sinterpreter-c-cpp:1.3.0
       poolSize: 0
     php:
-      image: aronmuon/k8sinterpreter-php:latest
+      image: ghcr.io/wipash/k8sinterpreter-php:1.3.0
       poolSize: 0
     r:
-      image: aronmuon/k8sinterpreter-r:latest
+      image: ghcr.io/wipash/k8sinterpreter-r:1.3.0
       poolSize: 0
     fortran:
-      image: aronmuon/k8sinterpreter-fortran:latest
+      image: ghcr.io/wipash/k8sinterpreter-fortran:1.3.0
       poolSize: 0
     d:
-      image: aronmuon/k8sinterpreter-d:latest
+      image: ghcr.io/wipash/k8sinterpreter-d:1.3.0
       poolSize: 0
 
   # Job settings (for languages with poolSize=0)


### PR DESCRIPTION
## Summary
- Migrate all container images from `aronmuon/*` to `ghcr.io/wipash/*`
- Dynamically generate image tags from `Chart.AppVersion` instead of hardcoding versions in `values.yaml`
- Add `imageSuffix` support for languages sharing an image (c/cpp use `c-cpp` image)

## Motivation
Previously, releasing a new version required manually updating 14+ image tags in `values.yaml` before tagging. Now the release workflow is:

1. Tag and push (e.g., `git tag 1.4.0 && git push --tags`)
2. CI builds/retags images with the tag version
3. CI publishes the Helm chart with matching `appVersion`
4. Users installing the chart automatically get matching images